### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ func main() {
 
 ### Usage with model images
 
-> Create images, please use `c.ImagesGenerations`, but if you want generate base64 image usage `c,InageGenerationsB64JSON`
+> Create images, please use `c.ImagesGenerations`, but if you want generate base64 image usage `c.ImageGenerationsB64JSON`
 
 ```go
 package main
@@ -115,7 +115,7 @@ func main() {
 }
 ```
 
-> Create images variations of a given image, please use `c.ImagesVariations()` but if you want generate base64 image usage `c,InageVariationsB64JSON`
+> Create images variations of a given image, please use `c.ImagesVariations()` but if you want generate base64 image usage `c.ImageVariationsB64JSON`
 
 ```go
 package main


### PR DESCRIPTION
Fix a typo in the README file where the word Image was misspelled as Inage in two instances.

Changed c,InageGenerationsB64JSON to c.ImageGenerationsB64JSON and c,InageVariationsB64JSON to c.ImageVariationsB64JSON.

This fix ensures that the code examples in the README file accurately reflect the correct function names and improve readability.