### PR TITLE
feat(structure): add response structs for model chat and model text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <img src="./assets/logo.png">
     <h2>go-chatgpt-sdk</h2>
-    <p>This Library Provides Unofficial Go client SDK for OpenAI API</p>
+    <p>This Library Provides Unofficial Go Client SDK for OpenAI API</p>
 </div>
 
 ### Install
@@ -141,4 +141,4 @@ func main() {
 }
 ```
 
-For all of return please read more in file [struct](./struct.go)
+For all of response struct please read more in file [struct_response.go](./struct_response.go)

--- a/struct.go
+++ b/struct.go
@@ -1,56 +1,5 @@
 package gochatgptsdk
 
-type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-type ModelChat struct {
-	Model            string    `json:"model"`
-	Messages         []Message `json:"messages"`
-	MaxTokens        int       `json:"max_tokens,omitempty"`
-	Temperature      int       `json:"temperature,omitempty"`
-	TopP             int       `json:"top_p,omitempty"`
-	FrequencyPenalty int       `json:"frequency_penalty,omitempty"`
-	PresencePenalty  int       `json:"presence_penalty,omitempty"`
-}
-
-type Choice struct {
-	Index        int     `json:"index"`
-	Message      Message `json:"message"`
-	FinishReason string  `json:"finish_reason"`
-}
-
-type ChoiceText struct {
-	Text         string      `json:"text"`
-	Index        int         `json:"index"`
-	Logprobs     interface{} `json:"logprobs"`
-	FinishReason string      `json:"finish_reason"`
-}
-
-type Usage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
-}
-
-type ModelChatResponse struct {
-	ID      string   `json:"id"`
-	Object  string   `json:"object"`
-	Created int64    `json:"created"`
-	Choices []Choice `json:"choices"`
-	Usage   Usage    `json:"usage"`
-}
-
-type ModelTextResponse struct {
-	ID      string       `json:"id"`
-	Object  string       `json:"object"`
-	Created int64        `json:"created"`
-	Model   string       `json:"model"`
-	Choices []ChoiceText `json:"choices"`
-	Usage   Usage        `json:"usage"`
-}
-
 type ModelText struct {
 	Model            string `json:"model"`
 	Prompt           string `json:"prompt"`
@@ -75,17 +24,4 @@ type ModelImagesVariations struct {
 	Size           string `json:"size,omitempty"`            // default 1024x1024
 	ResponseFormat string `json:"response_format,omitempty"` // url or b64_json
 	User           string `json:"user,omitempty"`
-}
-
-type DataURL struct {
-	URL string `json:"url"`
-}
-
-type DataB64JSON struct {
-	B64JSON string `json:"b64_json"`
-}
-
-type ModelImagesResponse[T DataURL | DataB64JSON] struct {
-	Created int64 `json:"created"`
-	Data    []T   `json:"data"`
 }

--- a/struct_response.go
+++ b/struct_response.go
@@ -1,0 +1,65 @@
+package gochatgptsdk
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ModelChat struct {
+	Model            string    `json:"model"`
+	Messages         []Message `json:"messages"`
+	MaxTokens        int       `json:"max_tokens,omitempty"`
+	Temperature      int       `json:"temperature,omitempty"`
+	TopP             int       `json:"top_p,omitempty"`
+	FrequencyPenalty int       `json:"frequency_penalty,omitempty"`
+	PresencePenalty  int       `json:"presence_penalty,omitempty"`
+}
+
+type Choice struct {
+	Index        int     `json:"index"`
+	Message      Message `json:"message"`
+	FinishReason string  `json:"finish_reason"`
+}
+
+type ChoiceText struct {
+	Text         string      `json:"text"`
+	Index        int         `json:"index"`
+	Logprobs     interface{} `json:"logprobs"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type ModelChatResponse struct {
+	ID      string   `json:"id"`
+	Object  string   `json:"object"`
+	Created int64    `json:"created"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type ModelTextResponse struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"`
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []ChoiceText `json:"choices"`
+	Usage   Usage        `json:"usage"`
+}
+
+type DataURL struct {
+	URL string `json:"url"`
+}
+
+type DataB64JSON struct {
+	B64JSON string `json:"b64_json"`
+}
+
+type ModelImagesResponse[T DataURL | DataB64JSON] struct {
+	Created int64 `json:"created"`
+	Data    []T   `json:"data"`
+}


### PR DESCRIPTION
This commit adds the response structs for the ModelChat and ModelText structs in the gochatgptsdk package. These response structs include fields such as ID, Object, Created, Choices, and Usage.

The response structs are necessary to properly handle the response data returned by the OpenAI API when making requests using the ModelChat and ModelText structs.

The following response structs have been added:
- ModelChatResponse
- ModelTextResponse

These response structs provide a structured representation of the response data returned by the OpenAI API for chat and text models.

For more details on the response structs, please refer to the newly added struct_response.go file.