### PR TITLE
feat(chat): add error handling

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -1,19 +1,28 @@
 package gochatgptsdk
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
-func (c *chatgpt) ChatCompletions(b ModelChat) (*ModelChatResponse, error) {
+func (c *chatgpt) ChatCompletions(b ModelChat) (*ModelChatResponse, *ErrorResponse) {
 	// POST https://api.openai.com/v1/chat/completions
 	endpointChatCompletions := fmt.Sprintf("%s/chat/completions", ChatGPTAPIV1)
 
 	result := ModelChatResponse{}
+	errMessage := ErrorResponse{}
 
-	_, err := DoRequest(c.OpenAIKey).
+	resp, err := DoRequest(c.OpenAIKey).
 		SetBody(b).
 		SetResult(&result).
+		SetError(&errMessage).
 		Post(endpointChatCompletions)
 	if err != nil {
-		return nil, err
+		return nil, &errMessage
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, &errMessage
 	}
 
 	return &result, nil

--- a/chat.go
+++ b/chat.go
@@ -10,19 +10,20 @@ func (c *chatgpt) ChatCompletions(b ModelChat) (*ModelChatResponse, *ErrorRespon
 	endpointChatCompletions := fmt.Sprintf("%s/chat/completions", ChatGPTAPIV1)
 
 	result := ModelChatResponse{}
-	errMessage := ErrorResponse{}
+	errResponse := ErrorResponse{}
 
 	resp, err := DoRequest(c.OpenAIKey).
 		SetBody(b).
 		SetResult(&result).
-		SetError(&errMessage).
+		SetError(&errResponse).
 		Post(endpointChatCompletions)
 	if err != nil {
-		return nil, &errMessage
+		return nil, &errResponse
 	}
 
+	// if status code not 200 ok, please send error message
 	if resp.StatusCode() != http.StatusOK {
-		return nil, &errMessage
+		return nil, &errResponse
 	}
 
 	return &result, nil

--- a/images.go
+++ b/images.go
@@ -1,51 +1,69 @@
 package gochatgptsdk
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
-func (c *chatgpt) ImagesGenerations(b ModelImages) (*ModelImagesResponse[DataURL], error) {
+func (c *chatgpt) ImagesGenerations(b ModelImages) (*ModelImagesResponse[DataURL], *ErrorResponse) {
 	// POST https://api.openai.com/v1/images/generations
 	endpointImagesGeneratios := fmt.Sprintf("%s/images/generations", ChatGPTAPIV1)
 
 	result := ModelImagesResponse[DataURL]{}
+	errorResponse := ErrorResponse{}
 
-	_, err := DoRequest(c.OpenAIKey).
+	resp, err := DoRequest(c.OpenAIKey).
 		SetBody(b).
 		SetResult(&result).
+		SetError(&errorResponse).
 		Post(endpointImagesGeneratios)
 	if err != nil {
-		return nil, err
+		return nil, &errorResponse
+	}
+
+	// if status code not 200 ok, please send error message
+	if resp.StatusCode() != http.StatusOK {
+		return nil, &errorResponse
 	}
 
 	return &result, nil
 }
 
-func (c *chatgpt) ImagesGenerationsB64JSON(b ModelImages) (*ModelImagesResponse[DataB64JSON], error) {
+func (c *chatgpt) ImagesGenerationsB64JSON(b ModelImages) (*ModelImagesResponse[DataB64JSON], *ErrorResponse) {
 	// POST https/api.openai.com/v1/images/generations
 	endpointImagesGeneratios := fmt.Sprintf("%s/images/generations", ChatGPTAPIV1)
 
 	result := ModelImagesResponse[DataB64JSON]{}
+	errorResponse := ErrorResponse{}
 
-	_, err := DoRequest(c.OpenAIKey).
+	resp, err := DoRequest(c.OpenAIKey).
 		SetBody(b).
 		SetResult(&result).
+		SetError(&errorResponse).
 		Post(endpointImagesGeneratios)
 	if err != nil {
-		return nil, err
+		return nil, &errorResponse
+	}
+
+	// if status code not 200 ok, please send error message
+	if resp.StatusCode() != http.StatusOK {
+		return nil, &errorResponse
 	}
 
 	return &result, nil
 }
 
-func (c *chatgpt) ImagesVariations(b ModelImagesVariations) (*ModelImagesResponse[DataURL], error) {
+func (c *chatgpt) ImagesVariations(b ModelImagesVariations) (*ModelImagesResponse[DataURL], *ErrorResponse) {
 	// POST https/api.openai.com/v1/images/variations
 	endpointImagesVariations := fmt.Sprintf("%s/images/variations", ChatGPTAPIV1)
 
 	result := ModelImagesResponse[DataURL]{}
+	errResponse := ErrorResponse{}
 
 	// set default images variations
 	d := defaultImagesVariations(b, ResponseFormatURL)
 
-	_, err := DoRequest(c.OpenAIKey).
+	resp, err := DoRequest(c.OpenAIKey).
 		SetFile("image", *&d.Image).
 		SetFormData(map[string]string{
 			"n":               d.N,
@@ -54,25 +72,32 @@ func (c *chatgpt) ImagesVariations(b ModelImagesVariations) (*ModelImagesRespons
 			"user":            d.User,
 		}).
 		SetResult(&result).
+		SetError(&errResponse).
 		Post(endpointImagesVariations)
 	if err != nil {
-		return nil, err
+		return nil, &errResponse
+	}
+
+	// if status code not 200 ok, please send error message
+	if resp.StatusCode() != http.StatusOK {
+		return nil, &errResponse
 	}
 
 	return &result, nil
 }
 
-func (c *chatgpt) ImagesVariationsB64JSON(b ModelImagesVariations) (*ModelImagesResponse[DataB64JSON], error) {
+func (c *chatgpt) ImagesVariationsB64JSON(b ModelImagesVariations) (*ModelImagesResponse[DataB64JSON], *ErrorResponse) {
 	// POST https/api.openai.com/v1/images/variations
 	endpointImagesVariations := fmt.Sprintf("%s/images/variations", ChatGPTAPIV1)
 
 	result := ModelImagesResponse[DataB64JSON]{}
+	errResponse := ErrorResponse{}
 
 	// set default images variations
 	d := defaultImagesVariations(b, ResponseFormatB64JSON)
 
-	_, err := DoRequest(c.OpenAIKey).
-		SetFile("image", *&b.Image).
+	resp, err := DoRequest(c.OpenAIKey).
+		SetFile("image", *&d.Image).
 		SetFormData(map[string]string{
 			"n":               d.N,
 			"size":            d.Size,
@@ -80,9 +105,15 @@ func (c *chatgpt) ImagesVariationsB64JSON(b ModelImagesVariations) (*ModelImages
 			"user":            d.User,
 		}).
 		SetResult(&result).
+		SetError(&errResponse).
 		Post(endpointImagesVariations)
 	if err != nil {
-		return nil, err
+		return nil, &errResponse
+	}
+
+	// if status code not 200 ok, please send error message
+	if resp.StatusCode() != http.StatusOK {
+		return nil, &errResponse
 	}
 
 	return &result, nil

--- a/struct_response.go
+++ b/struct_response.go
@@ -63,3 +63,14 @@ type ModelImagesResponse[T DataURL | DataB64JSON] struct {
 	Created int64 `json:"created"`
 	Data    []T   `json:"data"`
 }
+
+type Error struct {
+	Code    interface{} `json:"code"`
+	Message string      `json:"message"`
+	Param   interface{} `json:"param"`
+	Type    string      `json:"type"`
+}
+
+type ErrorResponse struct {
+	Error Error `json:"error"`
+}

--- a/text.go
+++ b/text.go
@@ -1,19 +1,29 @@
 package gochatgptsdk
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
-func (c *chatgpt) Completions(b ModelText) (*ModelTextResponse, error) {
+func (c *chatgpt) Completions(b ModelText) (*ModelTextResponse, *ErrorResponse) {
 	// POST https://api.openai.com/v1/completions
 	endpointCompletions := fmt.Sprintf("%s/completions", ChatGPTAPIV1)
 
 	result := ModelTextResponse{}
+	errResponse := ErrorResponse{}
 
-	_, err := DoRequest(c.OpenAIKey).
+	resp, err := DoRequest(c.OpenAIKey).
 		SetBody(b).
 		SetResult(&result).
+		SetError(&errResponse).
 		Post(endpointCompletions)
 	if err != nil {
-		return nil, err
+		return nil, &errResponse
+	}
+
+	// if status code not 200 ok, please send error message
+	if resp.StatusCode() != http.StatusOK {
+		return nil, &errResponse
 	}
 
 	return &result, nil


### PR DESCRIPTION
Add error handling for the  method in the  struct. Instead of returning just an error, the method now returns a  when an error occurs during the API request.

This provides more detailed information about the error, including the error message, error code, parameter, and error type.

The error handling is implemented in the  method where the API request is made. If an error occurs during the request or if the response status code is not , the  method returns a  instead of .

These changes ensure that any errors that occur during the  method are properly handled and provide more information about the error for better debugging.