### PR TITLE
feat(gochatgptsdk): add unit tests for chat, images, network, and tex…

### DIFF
--- a/chat_test.go
+++ b/chat_test.go
@@ -1,0 +1,30 @@
+package gochatgptsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChatCompletions(t *testing.T) {
+	c := NewConfig(Config{
+		OpenAIKey: "",
+	})
+
+	resp, err := c.ChatCompletions(ModelChat{
+		Model: "",
+		Messages: []Message{
+			{
+				Role:    "system",
+				Content: "",
+			},
+		},
+	})
+
+	assert.NotNil(t, err)
+	expectedErrType := &ErrorResponse{}
+	assert.IsType(t, expectedErrType, err)
+	assert.Nil(t, resp)
+	expectedRespType := &ModelChatResponse{}
+	assert.IsType(t, expectedRespType, resp)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,14 @@ module github.com/ak9024/go-chatgpt-sdk
 
 go 1.20
 
-require github.com/go-resty/resty/v2 v2.7.0
+require (
+	github.com/go-resty/resty/v2 v2.7.0
+	github.com/stretchr/testify v1.8.4
+)
 
-require golang.org/x/net v0.0.0-20211029224645-99673261e6eb // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20211029224645-99673261e6eb // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb h1:pirldcYWx7rx7kE5r+9WsOXPXK0+WH5+uZ7uPmJ44uM=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -7,3 +13,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/images_test.go
+++ b/images_test.go
@@ -1,0 +1,41 @@
+package gochatgptsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImagesGenerations(t *testing.T) {
+	c := NewConfig(Config{
+		OpenAIKey: "",
+	})
+
+	resp, err := c.ImagesGenerations(ModelImages{
+		Prompt: "",
+	})
+
+	assert.NotNil(t, err)
+	expectedErrType := &ErrorResponse{}
+	assert.IsType(t, expectedErrType, err)
+	assert.Nil(t, resp)
+	expectedRespType := &ModelImagesResponse[DataURL]{}
+	assert.IsType(t, expectedRespType, resp)
+}
+
+func TestImagesGenerationsBase64JSON(t *testing.T) {
+	c := NewConfig(Config{
+		OpenAIKey: "",
+	})
+
+	resp, err := c.ImagesGenerationsB64JSON(ModelImages{
+		Prompt: "",
+	})
+
+	assert.NotNil(t, err)
+	expectedErrType := &ErrorResponse{}
+	assert.IsType(t, expectedErrType, err)
+	assert.Nil(t, resp)
+	expectedRespType := &ModelImagesResponse[DataB64JSON]{}
+	assert.IsType(t, expectedRespType, resp)
+}

--- a/network.go
+++ b/network.go
@@ -1,0 +1,12 @@
+package gochatgptsdk
+
+import "github.com/go-resty/resty/v2"
+
+// DoRequest(t string) to compose HTTP Request
+func DoRequest(t string) *resty.Request {
+	client := resty.New()
+	return client.R().
+		EnableTrace().
+		SetHeader("Content-Type", "application/json").
+		SetAuthToken(t)
+}

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,23 @@
+package gochatgptsdk
+
+import (
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	token string
+)
+
+func TestNetwork(t *testing.T) {
+	_, err := DoRequest(token).Get("https://jsonplaceholder.typicode.com/todos/1")
+	assert.Nil(t, err)
+}
+
+func TestNetworkType(t *testing.T) {
+	req := DoRequest(token)
+	expectedType := &resty.Request{}
+	assert.IsType(t, expectedType, req)
+}

--- a/new.go
+++ b/new.go
@@ -1,7 +1,5 @@
 package gochatgptsdk
 
-import "github.com/go-resty/resty/v2"
-
 type chatgpt struct {
 	OpenAIKey string
 }
@@ -14,13 +12,4 @@ func NewConfig(c Config) *chatgpt {
 	return &chatgpt{
 		OpenAIKey: c.OpenAIKey,
 	}
-}
-
-// DoRequest(t string) to compose HTTP Request
-func DoRequest(t string) *resty.Request {
-	client := resty.New()
-	return client.R().
-		EnableTrace().
-		SetHeader("Content-Type", "application/json").
-		SetAuthToken(t)
 }

--- a/new_test.go
+++ b/new_test.go
@@ -1,0 +1,27 @@
+package gochatgptsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig(t *testing.T) {
+	c := Config{
+		OpenAIKey: "api key",
+	}
+	expectedType := ""
+	assert.IsType(t, expectedType, c.OpenAIKey)
+	expectedValue := "api key"
+	assert.Equal(t, expectedValue, c.OpenAIKey)
+}
+
+func TestInitNewConfig(t *testing.T) {
+	c := NewConfig(Config{
+		OpenAIKey: "api key",
+	})
+	expectedType := &chatgpt{}
+	assert.IsType(t, expectedType, c)
+	expectedValue := "api key"
+	assert.Equal(t, expectedValue, c.OpenAIKey)
+}

--- a/text_test.go
+++ b/text_test.go
@@ -1,0 +1,25 @@
+package gochatgptsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestText(t *testing.T) {
+	c := NewConfig(Config{
+		OpenAIKey: "",
+	})
+
+	resp, err := c.Completions(ModelText{
+		Model:  "",
+		Prompt: "",
+	})
+
+	assert.NotNil(t, err)
+	expectedErrType := &ErrorResponse{}
+	assert.IsType(t, expectedErrType, err)
+	assert.Nil(t, resp)
+	expectedRespType := &ModelTextResponse{}
+	assert.IsType(t, expectedRespType, resp)
+}


### PR DESCRIPTION
…t packages

Add unit test for the following packages: chat, images, network, and text. These tests ensure that the functions within each package are working correctly.

In the chat_test.go file:
- Add a unit test for the ChatCompletions function in the gochatgptsdk package.
- Create a new Config struct with an empty OpenAIKey.
- Call the ChatCompletions function with a ModelChat struct and assert that the response is not nil and the error is of type ErrorResponse.
- Assert that the response and error are both nil after the function call.
- Assert that the response is of type ModelChatResponse.

In the images_test.go file:
- Add a unit test for the ImagesGenerations function in the gochatgptsdk package.
- Create a new Config struct with an empty OpenAIKey.
- Call the ImagesGenerations function with a ModelImages