### PR TITLE
feat(workflow): add test coverage step to Go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,28 +1,26 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go
+name: Go tests coverage
+
+runs-on: ubuntu-latest
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
-jobs:
+steps:
+  - uses: actions/checkout@v3
 
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
+  - uses: actions/setup-go@v4
+    with:
+      go-version: "1.20"
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.20'
+  - name: Test
+    run: go test -v ./...-coverprofile=./cover.out
 
-    - name: Build
-      run: go build -v ./...
-
-    - name: Test
-      run: go test -v ./...
+  - name: check test coverage
+    uses: vladopajic/go-test-coverage@v2
+    with:
+      profile: cover.out
+      local-prefix: github.com/ak9024/go-chatgpt-sdk


### PR DESCRIPTION
Add a new step in the Go workflow to calculate test coverage. This step is used to ensure that the project's tests provide sufficient coverage. The step uses the PASS ok  	github.com/ak9024/go-chatgpt-sdk	1.958s command with the  flag to generate a coverage profile file named .

Additionally, the step uses the  action to check the test coverage and display it in the pull request. The action requires the  file and specifies the local prefix as .

This change was made to improve the quality and visibility of the project's test coverage.